### PR TITLE
proposal: 意思決定者の入力フォームをtextareaに変更

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/adr-any-decision-record.yml
+++ b/.github/DISCUSSION_TEMPLATE/adr-any-decision-record.yml
@@ -71,13 +71,14 @@ body:
       value: TBD
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: decision-makers
     attributes:
       label: Decision Makers - 意思決定者
       description: 決定に関わる全員をメンションしてください。
       placeholder: "@user1 @user2 ..."
-      value: <!-- 決定に関わる全員をメンションしてください。 例： @user1 @user2 ... -->
+      value: |
+        <!-- 決定に関わる全員をメンションしてください。 例： @user1 @user2 ... -->
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## 目的・背景

<!-- なぜこのマージリクエストを出したのか、実装を行ったのか、その目的・背景 (あれば今回対応しない内容) などを記載する -->

意思決定者の入力をする際、テキストボックスのためIDの補完が効かない
決定要因などと同様にtextareaに変更したいです

https://github.com/user-attachments/assets/989e8d0a-d689-4a4e-aa88-4e60687728f7

## 対応内容

<!--
対応内容を箇条書きで記載する

例：

- [機能A] ～
  - [機能A-1] ～
- [機能B] ～
-->

SSIA
